### PR TITLE
Use VK_EXT_subgroup_size_control to choose subgroup size

### DIFF
--- a/meshlettest.cpp
+++ b/meshlettest.cpp
@@ -327,6 +327,7 @@ public:
     m_contextInfo.addDeviceExtension(VK_EXT_MESH_SHADER_EXTENSION_NAME, true, &meshFeaturesEXT);
     m_contextInfo.addDeviceExtension(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME, true, &baryFeatures);
     m_contextInfo.addDeviceExtension(VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME, true, &pipePropFeatures);
+    m_contextInfo.addDeviceExtension(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME, true, NULL);
 #if 1
     m_contextInfo.removeInstanceLayer("VK_LAYER_KHRONOS_validation");
 #endif

--- a/resources_vk.cpp
+++ b/resources_vk.cpp
@@ -1059,6 +1059,15 @@ void ResourcesVK::initPipes()
   // enable manually for debugging etc.
   bool dumpPipeInternals = false && m_context->hasDeviceExtension(VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME);
 
+  VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT rss_info = {
+    .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT,
+    .requiredSubgroupSize = m_context->m_physicalInfo.properties11.subgroupSize,
+  };
+
+  VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT *rss_info_ptr = NULL;
+  if (m_context->hasDeviceExtension(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
+    rss_info_ptr = &rss_info;
+
   for(uint32_t isNV = 0; isNV < 2; isNV++)
   {
     if((isNV && !m_supportsMeshNV) || (!isNV && !m_supportsMeshEXT))
@@ -1078,8 +1087,10 @@ void ResourcesVK::initPipes()
       pipelineInfo.stageCount = 2;
       stages[0].stage         = VK_SHADER_STAGE_MESH_BIT_NV;
       stages[0].module        = m_shaderManager.get(shaders.mesh);
+      stages[0].pNext         = rss_info_ptr;
       stages[1].stage         = VK_SHADER_STAGE_FRAGMENT_BIT;
       stages[1].module        = m_shaderManager.get(shaders.mesh_fragment);
+      stages[1].pNext         = NULL;
 
       result = vkCreateGraphicsPipelines(m_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &setup.pipeline);
       assert(result == VK_SUCCESS);
@@ -1094,10 +1105,13 @@ void ResourcesVK::initPipes()
       pipelineInfo.stageCount = 3;
       stages[0].stage         = VK_SHADER_STAGE_TASK_BIT_NV;
       stages[0].module        = m_shaderManager.get(shaders.task);
+      stages[0].pNext         = rss_info_ptr;
       stages[1].stage         = VK_SHADER_STAGE_MESH_BIT_NV;
       stages[1].module        = m_shaderManager.get(shaders.task_mesh);
+      stages[1].pNext         = rss_info_ptr;
       stages[2].stage         = VK_SHADER_STAGE_FRAGMENT_BIT;
       stages[2].module        = m_shaderManager.get(shaders.mesh_fragment);
+      stages[2].pNext         = NULL;
 
       result = vkCreateGraphicsPipelines(m_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &setup.pipelineTask);
       assert(result == VK_SUCCESS);
@@ -1113,8 +1127,10 @@ void ResourcesVK::initPipes()
       pipelineInfo.stageCount = 2;
       stages[0].stage         = VK_SHADER_STAGE_MESH_BIT_NV;
       stages[0].module        = m_shaderManager.get(shaders.cull_mesh);
+      stages[0].pNext         = rss_info_ptr;
       stages[1].stage         = VK_SHADER_STAGE_FRAGMENT_BIT;
       stages[1].module        = m_shaderManager.get(shaders.mesh_fragment);
+      stages[1].pNext         = NULL;
 
       result = vkCreateGraphicsPipelines(m_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &setup.pipelineCull);
       assert(result == VK_SUCCESS);
@@ -1124,10 +1140,13 @@ void ResourcesVK::initPipes()
       pipelineInfo.stageCount = 3;
       stages[0].stage         = VK_SHADER_STAGE_TASK_BIT_NV;
       stages[0].module        = m_shaderManager.get(shaders.task);
+      stages[0].pNext         = rss_info_ptr;
       stages[1].stage         = VK_SHADER_STAGE_MESH_BIT_NV;
       stages[1].module        = m_shaderManager.get(shaders.cull_task_mesh);
+      stages[1].pNext         = rss_info_ptr;
       stages[2].stage         = VK_SHADER_STAGE_FRAGMENT_BIT;
       stages[2].module        = m_shaderManager.get(shaders.mesh_fragment);
+      stages[2].pNext         = NULL;
 
       result = vkCreateGraphicsPipelines(m_device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &setup.pipelineCullTask);
       assert(result == VK_SUCCESS);


### PR DESCRIPTION
VkPhysicalDeviceVulkan11Properties.subgroupSize is weakly defined, so tell the driver that we want this particular size and no other.