### PR TITLE
Disable creation of queues we won't need.

### DIFF
--- a/meshlettest.cpp
+++ b/meshlettest.cpp
@@ -359,6 +359,9 @@ public:
         feature->meshShaderQueries = VK_FALSE;
       }
     };
+    // we don't need all queues
+    m_contextInfo.requestedQueues.clear();
+    m_contextInfo.addRequestedQueue(m_contextInfo.defaultQueueGCT);
 #endif
   }
 


### PR DESCRIPTION
~~Requires https://github.com/nvpro-samples/nvpro_core/pull/47.~~

This fixes initialization on Intel Arc Mesa drivers, which currently don't expose enough queues.