### PR TITLE
Add hidden marker to buttons sharing the same text.

### DIFF
--- a/meshlettest.cpp
+++ b/meshlettest.cpp
@@ -934,7 +934,7 @@ void Sample::processUI(int width, int height, double time)
 #if IS_VULKAN
     if(m_supportsEXT && ImGui::CollapsingHeader("EXT Mesh Shading Preferences"))
     {
-      if(ImGui::Button("RESET to implementation DEFAULTS"))
+      if(ImGui::Button("RESET to implementation DEFAULTS##ext prefs"))
       {
         resetEXTtweaks(true);
       }
@@ -948,7 +948,7 @@ void Sample::processUI(int width, int height, double time)
     }
     if(m_supportsSubgroupControl && ImGui::CollapsingHeader("Subgroup Size Control Preferences"))
     {
-      if(ImGui::Button("RESET to implementation DEFAULTS"))
+      if(ImGui::Button("RESET to implementation DEFAULTS##subgroups"))
       {
         resetSubgroupTweaks(true);
       }


### PR DESCRIPTION
~~When two buttons share the same text (used few lines above), then for some reason the second button works only once.~~

ImGui uses button text as a sort of ID, so when two buttons use the same text, they get mixed up, and the second button
works only once.
    
Resolve this by appending ## marker with unique text, which ImGui doesn't display, but uses to tell buttons apart.

