### PR TITLE
Fix bugs related to subgroups and tune default subgroup size.

### DIFF
--- a/meshlettest.cpp
+++ b/meshlettest.cpp
@@ -839,6 +839,8 @@ bool Sample::begin()
     m_ui.enumAdd(GUI_MESHLET_PRIMITIVES, 126, "126");
     m_ui.enumAdd(GUI_MESHLET_PRIMITIVES, 128, "128");
 
+    m_ui.enumAdd(GUI_THREADS, 8, "8");
+    m_ui.enumAdd(GUI_THREADS, 16, "16");
     m_ui.enumAdd(GUI_THREADS, 32, "32");
     m_ui.enumAdd(GUI_THREADS, 64, "64");
     m_ui.enumAdd(GUI_THREADS, 96, "96");

--- a/meshlettest.cpp
+++ b/meshlettest.cpp
@@ -326,6 +326,12 @@ public:
     {
       m_tweak.subgroupSize                    = m_context.m_physicalInfo.properties11.subgroupSize;
 
+      if(m_supportsEXT && m_supportsSubgroupControl) {
+        m_tweak.subgroupSize = std::min({m_tweak.subgroupSize,
+                                         m_meshPropertiesEXT.maxPreferredTaskWorkGroupInvocations,
+                                         m_meshPropertiesEXT.maxPreferredMeshWorkGroupInvocations});
+      }
+
       if(m_tweak.numTaskMeshlets != ~0)
         fixupNumTaskMeshlets();
     }
@@ -739,7 +745,6 @@ bool Sample::begin()
     props2.pNext                       = &m_subgroupSizeProperties;
     vkGetPhysicalDeviceProperties2(m_context.m_physicalDevice, &props2);
   }
-  resetSubgroupTweaks(false);
 
   if(m_context.hasDeviceExtension(VK_EXT_MESH_SHADER_EXTENSION_NAME) || m_context.hasDeviceExtension(VK_NV_MESH_SHADER_EXTENSION_NAME))
   {
@@ -763,9 +768,11 @@ bool Sample::begin()
     VkPhysicalDeviceProperties2 props2 = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
     props2.pNext                       = &m_meshPropertiesEXT;
     vkGetPhysicalDeviceProperties2(m_context.m_physicalDevice, &props2);
-
-    resetEXTtweaks(false);
   }
+
+  resetSubgroupTweaks(false);
+  if(m_supportsEXT)
+    resetEXTtweaks(false);
   else {
     if(m_tweak.numTaskMeshlets == ~0)
     {

--- a/meshlettest.cpp
+++ b/meshlettest.cpp
@@ -823,6 +823,8 @@ bool Sample::begin()
     m_ui.enumAdd(GUI_MESHLET_VERTICES, 96, "96");
     m_ui.enumAdd(GUI_MESHLET_VERTICES, 128, "128");
 
+    m_ui.enumAdd(GUI_TASK_MESHLETS, 8, "8");
+    m_ui.enumAdd(GUI_TASK_MESHLETS, 16, "16");
     m_ui.enumAdd(GUI_TASK_MESHLETS, 32, "32");
     m_ui.enumAdd(GUI_TASK_MESHLETS, 64, "64");
     m_ui.enumAdd(GUI_TASK_MESHLETS, 96, "96");


### PR DESCRIPTION
Without the first 2 commits, UI can lie about workgroup size and meshlet count, because if the current value is not among the ones listed in the code, then UI shows the first value (32).

Without the 3rd commit, meshlet count can be lower than the subgroup size, which leads to geometry corruptions.

4th commit tunes the default subgroup size, to take into account the preferred values exposed by the driver.